### PR TITLE
replace Perl::Critic::Utils with PPIx::Utils

### DIFF
--- a/lib/PPI/Prettify.pm
+++ b/lib/PPI/Prettify.pm
@@ -4,7 +4,7 @@ use warnings;
 use PPI::Document;
 use Carp 'croak';
 use HTML::Entities;
-use Perl::Critic::Utils qw/is_method_call is_subroutine_name is_package_declaration/;
+use PPIx::Utils qw/is_method_call is_subroutine_name is_package_declaration/;
 use B::Keywords;
 use List::MoreUtils 'any';
 


### PR DESCRIPTION
PPIx::Utils is a fork of the functions in Perl::Critic::Utils for use without bringing in the whole Perl::Critic dependency chain.

Ref: https://github.com/adamkennedy/PPI/issues/78